### PR TITLE
Update 343-use-metadata-in-write-to-table.rst

### DIFF
--- a/Articles/343/343-use-metadata-in-write-to-table.rst
+++ b/Articles/343/343-use-metadata-in-write-to-table.rst
@@ -47,9 +47,9 @@ As you can see from this schema, both a customer and a product have an ``Id``.  
 
     In words: For each ``CustomerId``, it should be in the set of all ``Id`` in the table ``Customers``.
 
-*   :math:`\forall {\tt ProjectId}: {\tt ProjectId} \in \{Project.Id\}` 
+*   :math:`\forall {\tt ProductId}: {\tt ProductId} \in \{Product.Id\}` 
 
-    In words: For each ``ProjectId``, it should be in the set of all ``Id`` in the table ``Projects``.
+    In words: For each ``ProductId``, it should be in the set of all ``Id`` in the table ``Products``.
 
 Foreign keys relations
 ------------------------
@@ -247,7 +247,7 @@ In our example, tables are best written to with the options ``Database_foreign_k
                 database_string_valued_foreign_keys := 'ignore'  ;
 
         write to table db_Customers ;
-        write to table db_Projects ;
+        write to table db_Products ;
 
     endblock ;
 


### PR DESCRIPTION
Changed the "Project" reference to "Product" as it seems that the example uses Product, not Project. 
Also: the image of the tables calls the table "Product" but in the text "Products" (with an "s") is used. The image or the text should be changed.